### PR TITLE
Run buster via a relative path

### DIFF
--- a/bin/buster
+++ b/bin/buster
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var fs = require("fs");
+var Path = require("path");
 var childProcess = require("child_process");
 
 var argv = Array.prototype.slice.call(process.argv).slice(2)
@@ -35,7 +36,7 @@ function printVersions() {
 
 function runBusterCmd() {
     childProcess.exec(
-        "command -v buster-" + cmd,
+        "command -v " + Path.join( __dirname, "buster-" + cmd),
         {env: process.env},
         function (error, stdout, stderr) {
             if (error) {


### PR DESCRIPTION
Now it's possible to call buster in a relative path, without a global buster instance : 

I don't like to install npm packages globally. I prefer local install, that's why I did this.

Before 

```
$ cd myProject
$ npm i -S buster
$ ./node_modules/.bin/buster test
Buster command 'test' does not exist.
```

Now it works.
