### PR TITLE
Summary headline of report in green or red.

### DIFF
--- a/resources/buster-test.css
+++ b/resources/buster-test.css
@@ -82,6 +82,14 @@ body.buster-test {
     margin: 0 0 .25em;
 }
 
+.buster-test .stats.success h2 {
+    color: #3c3;
+}
+
+.buster-test .stats.failure h2 {
+    color: #c33;
+}
+
 .buster-test .stats li {
     display: inline;
     padding-right: 1em;


### PR DESCRIPTION
If all tests that are shown above the fold in the report page are green then there is no red immediately visible to smack me in the face that there was an error hiding below the fold. I actually have to read the words "Test failures!" which is hard work.
