### PR TITLE
fix phantomjs default capture url

### DIFF
--- a/script/phantom.js
+++ b/script/phantom.js
@@ -1,5 +1,5 @@
 var system = require('system'),
-    captureUrl = 'http://localhost:1111/capture/';
+    captureUrl = 'http://localhost:1111/capture';
 if (system.args.length==2) {
     captureUrl = system.args[1];
 }


### PR DESCRIPTION
/capture/ does not work anymore with latest buster-server
