### PR TITLE
Lazyload the testRunner

### DIFF
--- a/lib/buster/capture-server-wiring.js
+++ b/lib/buster/capture-server-wiring.js
@@ -1,9 +1,12 @@
 (function (B) {
     function wireTestRunner(emitter) {
-        var runner = B.testRunner.create();
-        var reporter = B.reporters.jsonProxy.create(emitter);
-        reporter.listen(runner);
-        var wiring = B.wire.testRunner(runner);
+
+        var wiring = B.wire.testRunner(function () {
+            var runner = B.testRunner.create();
+            var reporter = B.reporters.jsonProxy.create(emitter);
+            reporter.listen(runner);
+            return runner;
+        });
         B.run = wiring.run;
 
         emitter.on("tests:run", function (msg) {


### PR DESCRIPTION
This has already been done in https://github.com/busterjs/buster-test-cli/commit/af72c0172bcdc8e97668b9107160e09ed57d6c45 but I guess got somehow lost in the transition.
