### PR TITLE
Update test CSS vendor prefixes

### DIFF
--- a/resources/buster-test.css
+++ b/resources/buster-test.css
@@ -115,26 +115,15 @@ body.buster-test {
 /* Masthead */
 .buster-test h1 {
     background: #333;
-
-    background: -webkit-gradient(
-        linear,
-        left top,
-        left bottom,
-        from(#5f5f5f),
-        to(#222)
-    );
-
-    background: -moz-linear-gradient(
-        top center,
-        #5f5f5f,
-        #222
-    );
-
-    /* For Internet Explorer 5.5 - 7 */
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#ff5f5f5f, endColorstr=#ff222222);
     /* For Internet Explorer 8 */
     -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#ff5f5f5f, endColorstr=#ff222222)";
     zoom: 1;
+
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#5f5f5f), to(#222));
+    background-image: -webkit-linear-gradient(top, #5f5f5f, #222);
+    background-image: -moz-linear-gradient(top, #5f5f5f, #222);
+    background-image: -o-linear-gradient(top, #5f5f5f, #222);
+    background-image: linear-gradient(to bottom, #5f5f5f, #222);
 
     border-bottom: 4px solid #c0c6cc;
     box-shadow: 0 0 10px #ddd;


### PR DESCRIPTION
- Add gradient prefixes for Opera, IE9, and new webkit gradient syntax.
- Remove IE7 filter gradients. Data URI's are being used already, which rules out IE7 support.
