### PR TITLE
Change when package dependency to not use https

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "buster-autotest": ">=0.2.0",
         "buster-static": ">=0.5",
         "buster-syntax": "~0.4",
-        "when": "https://github.com/cujojs/when/tarball/1.3.0"
+        "when": "http://github.com/cujojs/when/tarball/1.3.0"
     },
     "devDependencies": {
         "uglify-js": "~1.2.5",


### PR DESCRIPTION
This is a common workaround to installing packages with https dependency using npm from behind a corporate proxy.

The problem is with installing any package via https from behind a corporate proxy: https://github.com/isaacs/npm/issues/2866 . There are a number of other tickets with the same problem, AFAIK no obvious solution so far.
