### PR TITLE
Throw assertion errors for asynchronous tests by default.

### DIFF
--- a/lib/buster/buster-wiring.js
+++ b/lib/buster/buster-wiring.js
@@ -62,10 +62,6 @@
             buster.assertions.bind(runner, { "failure": "assertionFailure" });
             runner.console = buster.console;
 
-            runner.on("test:async", function () {
-                buster.assertions.throwOnFailure = true;
-            });
-
             runner.on("test:setUp", function () {
                 buster.assertions.throwOnFailure = true;
             });


### PR DESCRIPTION
The flag `buster.assertions.throwOnFailure` should be set to `true` for asynchronous tests as well. Otherwise the flow control is not aborted. Before the error is thrown, a "failure"-event is emitted in any case. Therefore it is guaranteed that the error is tracked.
There should be no need to prevent throwing assertion errors in asynchronous tests.

This would solve the issue <a href="https://github.com/busterjs/buster/issues/266">#266 test execution does not always stop in async tests after a failed assertion</a>.
