### PR TITLE
Prefix when.js resource path for buster server/static

### DIFF
--- a/lib/buster/framework-extension.js
+++ b/lib/buster/framework-extension.js
@@ -22,7 +22,7 @@ var NO_CACHE_HEADERS = {
 function loadTestFramework(configuration) {
     configuration.on("load:framework", function (rs) {
         rs.addResource({
-            path: "/when.js",
+            path: "/buster/when.js",
             file: require.resolve("when")
         });
         var files = resolveModules(rs, [
@@ -77,7 +77,7 @@ function loadTestFramework(configuration) {
             }),
             rs.addResource({
                 path: bundleResourceName,
-                combine: ["/when.js"].concat(files),
+                combine: ["/buster/when.js"].concat(files),
                 headers: NO_CACHE_HEADERS
             })
         ], function () {


### PR DESCRIPTION
when.js is currently mounted at '/when.js' before being concatenated into
'/buster/bundle-0.6.js'. This can conflict with projects that have a file
in the rootPath named 'when.js' if it is exposed as a resource. In this
case, the project specific when.js is used instead of the when.js buster
intended.

Adding a '/buster' prefix to '/when.js' as the intended file is buster's
dependency and not the project's.
