### PR TITLE
Add missing Sinon.JS behavior module

### DIFF
--- a/lib/buster/framework-extension.js
+++ b/lib/buster/framework-extension.js
@@ -36,6 +36,7 @@ function loadTestFramework(configuration) {
             ["sinon/lib/", "sinon.js"],
             ["sinon/lib/", "sinon/spy.js"],
             ["sinon/lib/", "sinon/call.js"],
+            ["sinon/lib/", "sinon/behavior.js"],
             ["sinon/lib/", "sinon/stub.js"],
             ["sinon/lib/", "sinon/mock.js"],
             ["sinon/lib/", "sinon/collection.js"],


### PR DESCRIPTION
Missing behavior module is breaking stubs when stubs are invoked.
Adding missing behavior module fixes the problem.
