### PR TITLE
allow more than 3 arguments in handleUncaughtError()

### DIFF
--- a/lib/buster/browser-wiring.js
+++ b/lib/buster/browser-wiring.js
@@ -12,7 +12,7 @@
     // Globally uncaught errors will be emitted as messages through
     // the test runner
     function handleUncaughtError(runner, args) {
-        if (args.length === 3) {
+        if (args.length >= 3) {
             var message = args[0];
             var url = args[1];
             var line = args[2];


### PR DESCRIPTION
This is probably a recent change in the browsers - Firefox and Chrome now both have 5 arguments to `window.onerror`

https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers.onerror

This fixes `Uncaught exception: undefined` at the start of the test run into an actually readable `Uncaught exception: ./index.test.js:1 Uncaught ReferenceError: require is not defined` (or whatever the error was)

Part of https://github.com/busterjs/buster/issues/422
